### PR TITLE
Issues/21

### DIFF
--- a/JupyterHubSingularity
+++ b/JupyterHubSingularity
@@ -1,0 +1,12 @@
+Bootstrap: docker
+From: centos:latest
+
+%environment
+  export PATH=/usr/local/bin:$PATH
+
+%post
+  yum install -y epel-release && yum repolist
+  yum install -y python34-devel python34-pip
+  pip3 install --upgrade pip
+  pip3 install jupyterhub==0.7.2
+  pip3 install --upgrade notebook

--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
 # jupyterhub-singularity-spawner
 Spawn user-specified Singularity containers with JupyterHub.
+
+## Dev Installation
+To install Singularity Spawner, clone the repo and do an editable pip install in your JupyterHub environment:
+```
+git clone https://github.com/ResearchComputing/jupyterhub-singularity-spawner.git
+cd jupyterhub-singularity-spawner
+pip install -e .
+```
+
+## Configuration
+A basic configuration for Singularity Spawner _(in the JupyterHub config file)_:
+```python
+c.JupyterHub.spawner_class = 'singularityspawner.singularityspawner.SingularitySpawner'
+c.SingularitySpawner.default_image_path = "/home/<username>/singularity/jupyter.img"
+```
+
+## Running Notebooks with Singularity
+_**Note:** The manifest in this repo depends on the docker bootstrap method, so the Docker daemon must be installed and running._
+
+This repo comes with a minimal Singularity manifest for running `jupyterhub-singleuser` within a Singularity container. To build the image _(using Singularity v2.3.1)_:
+```
+singularity create jupyter.img
+sudo singularity bootstrap jupyter.img jupyter.def
+```

--- a/jupyter.def
+++ b/jupyter.def
@@ -1,12 +1,15 @@
 Bootstrap: docker
-From: centos:latest
+From: centos:7
 
 %environment
   export PATH=/usr/local/bin:$PATH
+  export XDG_RUNTIME_DIR=/tmp/.run/user/$UID
 
 %post
+  echo "Installing dependencies..."
   yum install -y epel-release && yum repolist
   yum install -y python34-devel python34-pip
+  echo "Installing JupyterHub..."
   pip3 install --upgrade pip
   pip3 install jupyterhub==0.7.2
   pip3 install --upgrade notebook

--- a/singularityspawner/singularityspawner.py
+++ b/singularityspawner/singularityspawner.py
@@ -29,7 +29,7 @@ class SingularitySpawner(LocalProcessSpawner):
     2) Spawning a Notebook server within a Singularity container
     """
 
-    singularity_cmd = Command(['singularity','exec'],
+    singularity_cmd = Command(['/usr/local/bin/singularity','exec'],
         help="""
         This is the singularity command that will be executed when starting the
         singule-user server. The image path and notebook server args will be concatenated to the end of this command. This is a good place to
@@ -70,7 +70,7 @@ class SingularitySpawner(LocalProcessSpawner):
         cmd.extend(self.singularity_cmd)
         cmd.extend(image_path)
         cmd.extend(self.cmd)
-        return ' '.join(cmd)
+        return cmd
 
     @gen.coroutine
     def start(self):

--- a/singularityspawner/singularityspawner.py
+++ b/singularityspawner/singularityspawner.py
@@ -7,3 +7,56 @@ SingularitySpawner provides a mechanism for spawning Jupyter Notebooks inside of
 
 A `singularity exec {notebook spawn cmd}` is used to start the notebook inside of the container.
 """
+import os
+import pipes
+
+from tornado import gen
+from tornado.process import Subprocess
+from tornado.iostream import StreamClosedError
+
+from jupyterhub.spawner import (
+    LocalProcessSpawner, set_user_setuid
+)
+from jupyterhub.utils import random_port
+from traitlets import (
+    Integer, Unicode, Float, Dict, Command, default
+)
+
+class SingularitySpawner(LocalProcessSpawner):
+    """SingularitySpawner - extends the default LocalProcessSpawner to allow for:
+    1) User-specification of a singularity image via the Spawner options form
+    2) Spawning a Notebook server within a Singularity container
+    """
+
+    singularity_cmd = Command(['singularity','exec'],
+        help="""
+        This is the singularity command that will be executed when starting the
+        singule-user server. The image path and notebook server args will be concatenated to the end of this command. This is a good place to
+        specify any site-specific options that should be applied to all users,
+        such as default mounts.
+        """
+    )
+
+    default_image_path = Unicode('',
+        help="""
+        Absolute POSIX filepath to Singularity image that will be used to
+        execute the notebook server spawn command, if another path is not
+        specified by the user.
+        """
+    ).tag(config=True)
+
+    def _build_cmd(self):
+        cmd = []
+        cmd.extend(self.singularity_cmd)
+        cmd.append(default_image_path)
+        cmd.extend(self.cmd)
+        self.cmd = cmd
+
+    @gen.coroutine
+    def start(self):
+        """
+        Start the single-user server, after building the new singularity
+        for this instance.
+        """
+        self.cmd = self._build_cmd()
+        super(SingularitySpawner,self).start()


### PR DESCRIPTION
Closes ResearchComputing/jupyter-at-rc#21.

Changelist:
* Added basic SingularitySpawner class that extends LocalProcessSpawner
* Spawner starts a notebook server in a locally-accessible singularity image
* `options_form` allows the user to specify image to exec in
* Added minimal Singularity manifest for spawning jupyter singleuser servers